### PR TITLE
Reduce network size and scale residual torque

### DIFF
--- a/rl_simple.py
+++ b/rl_simple.py
@@ -28,7 +28,7 @@ class RLConfig:
     lr: float = 1e-3           # learning rate for weight updates
     sigma: float = 0.1         # exploration std (Nm)
     gamma: float = 0.995       # return discount factor
-    u_rl_max: float = 0.18     # residual torque bound
+    u_rl_max: float = 0.16     # residual torque bound (≈20% of SMC torque limit)
     feature_clip: float = 5.0  # clip features to stabilize
 
 class SimpleResidualPolicy(ResidualAgentAPI):
@@ -92,10 +92,13 @@ class SimpleResidualPolicy(ResidualAgentAPI):
     def save(self, name: str, out_dir: str = "agents"):
         os.makedirs(out_dir, exist_ok=True)
         path = os.path.join(out_dir, f"{name}_simple.npz")
-        np.savez(path, w=self.w, cfg=np.array([self.cfg.lr, self.cfg.sigma, self.cfg.gamma, self.cfg.u_rl_max, self.cfg.feature_clip], dtype=np.float32))
-        with open(os.path.join(out_dir, f"{name}_simple.readme.txt"), 'w') as f:
-            f.write("Linear residual policy (REINFORCE). Keys: w, cfg=[lr,sigma,gamma,u_rl_max,feature_clip]
-")
+        np.savez(
+            path,
+            w=self.w,
+            cfg=np.array([self.cfg.lr, self.cfg.sigma, self.cfg.gamma, self.cfg.u_rl_max, self.cfg.feature_clip], dtype=np.float32),
+        )
+        with open(os.path.join(out_dir, f"{name}_simple.readme.txt"), "w") as f:
+            f.write("Linear residual policy (REINFORCE). Keys: w, cfg=[lr,sigma,gamma,u_rl_max,feature_clip]")
 
     def load(self, name: str, in_dir: str = "agents"):
         path = os.path.join(in_dir, f"{name}_simple.npz")


### PR DESCRIPTION
## Summary
- shrink SAC actor/critic MLPs to two 32-unit layers for lighter models
- cap residual RL torque to 20% of the TDE-SMC torque limit and compute it from plant settings
- adjust config defaults and helpers accordingly

## Testing
- `python -m py_compile rl_sac.py rl_simple.py LQR_TrjOPt_TDESMCwithRLresidual.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1c7fa92fc8328a55755e32a891177