### PR TITLE
Add omega tracking figure to evaluation plots

### DIFF
--- a/LQR_TrjOPt_TDESMCwithRLresidual.py
+++ b/LQR_TrjOPt_TDESMCwithRLresidual.py
@@ -985,6 +985,15 @@ if __name__ == "__main__":
         axes[3].set_xlabel('Time [s]')
         axes[3].legend(loc='best')
 
+        plt.figure()
+        plt.plot(logs_smc['t'], logs_smc['omega_ref'], 'k--', linewidth=1.1, label='Reference ω')
+        plt.plot(logs_smc['t'], logs_smc['omega'], label='TDE+SMC ω')
+        if logs_agent is not None:
+            plt.plot(logs_agent['t'], logs_agent['omega'], label='RL+SMC ω')
+        plt.xlabel('Time [s]')
+        plt.ylabel('ω [rad/s]')
+        plt.legend(loc='best')
+
         fig.tight_layout(rect=[0, 0, 1, 0.97])
         plt.show()
 


### PR DESCRIPTION
## Summary
- add a dedicated omega tracking figure for each evaluation case
- plot reference and controller angular velocities alongside the existing subplots

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d78f82138c8328a1854018cd9501eb