### PR TITLE
Penalize RL residual effort (u_rl) instead of total command

### DIFF
--- a/LQR_TrjOPt_TDESMCwithRLresidual.py
+++ b/LQR_TrjOPt_TDESMCwithRLresidual.py
@@ -723,7 +723,7 @@ def rollout_once(
             cost_cfg.w_e * e * e
             + cost_cfg.w_edot * edot * edot
             + cost_cfg.w_omega * omega * omega
-            + cost_cfg.w_u * info['u_total'] * info['u_total']
+            + cost_cfg.w_u * u_rl * u_rl
         )
         r = -stage * dt
         total_cost += stage * dt

--- a/Main.py
+++ b/Main.py
@@ -378,7 +378,7 @@ def rollout_once(
         stage = (cost_cfg.w_e * e * e
                  + cost_cfg.w_edot * edot * edot
                  + cost_cfg.w_omega * omega * omega
-                 + cost_cfg.w_u * u_cmd * u_cmd)
+                 + cost_cfg.w_u * u_rl * u_rl)
         r = -stage * dt
         total_cost += stage * dt
 


### PR DESCRIPTION
### Motivation
- Avoid penalizing the RL agent for torque produced by the baseline TDE+SMC controller by applying the effort penalty only to the RL residual `u_rl` rather than the total command `u_cmd`/`u_total` so training focuses on residual effort.

### Description
- Updated the per-step stage cost in both rollout implementations to use `cost_cfg.w_u * u_rl * u_rl` instead of penalizing the total command (`u_cmd * u_cmd` or `info['u_total'] * info['u_total']`), while leaving `plant.step(u_cmd)` and all logging of `u_total`/`u_cmd` intact and keeping the `w_u` parameter name.

### Testing
- Performed a quick static verification that the rollout occurrences were updated and attempted a short smoke training run for both SIMPLE and SAC with `total_steps=20`, but the runtime smoke test could not complete in this environment due to a missing dependency (`ModuleNotFoundError: No module named 'numpy'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ee34b2b6688328a7fff3f5922d4a76)