### PR TITLE
Unify trajectory objective metric naming and add validation

### DIFF
--- a/sac_gps_lqr_guided_saved_teacher_addon.py
+++ b/sac_gps_lqr_guided_saved_teacher_addon.py
@@ -328,15 +328,15 @@ def evaluate_action(case, action, traj_cfg, obj_cfg, sac_cfg, baseline_cache, se
     existing_metrics, existing_logs, existing_ref, existing_T = baseline_cache.get(case, seed=seed)
     try:
         metrics, logs, theta_ref, T, extra, base_ref, base_T = gps.evaluate_guided_params(case, params, traj_cfg, obj_cfg, seed=seed)
-        cost = float(metrics["total"])
+        cost = float(metrics["total_cost"])
         failed = False
     except Exception:
         metrics, logs, theta_ref, T, extra, base_ref, base_T = None, None, None, None, None, existing_ref, existing_T
-        cost = float(existing_metrics["total"] + 1e8)
+        cost = float(existing_metrics["total_cost"] + 1e8)
         failed = True
-    raw_reward = (float(existing_metrics["total"]) - cost) / max(sac_cfg.reward_scale, 1e-12)
+    raw_reward = (float(existing_metrics["total_cost"]) - cost) / max(sac_cfg.reward_scale, 1e-12)
     reward = float(np.clip(raw_reward, -sac_cfg.reward_clip, sac_cfg.reward_clip))
-    return dict(case=case, action=np.asarray(action, dtype=np.float32), params=params, reward=reward, raw_reward=float(raw_reward), cost=cost, existing_cost=float(existing_metrics["total"]), improvement_pct=100.0 * (float(existing_metrics["total"]) - cost) / max(abs(float(existing_metrics["total"])), 1e-12), metrics=metrics, logs=logs, theta_ref=theta_ref, T=T, extra=extra, existing_metrics=existing_metrics, existing_logs=existing_logs, existing_ref=existing_ref, existing_T=existing_T, base_ref=base_ref, base_T=base_T, failed=failed)
+    return dict(case=case, action=np.asarray(action, dtype=np.float32), params=params, reward=reward, raw_reward=float(raw_reward), cost=cost, existing_cost=float(existing_metrics["total_cost"]), improvement_pct=100.0 * (float(existing_metrics["total_cost"]) - cost) / max(abs(float(existing_metrics["total_cost"])), 1e-12), metrics=metrics, logs=logs, theta_ref=theta_ref, T=T, extra=extra, existing_metrics=existing_metrics, existing_logs=existing_logs, existing_ref=existing_ref, existing_T=existing_T, base_ref=base_ref, base_T=base_T, failed=failed)
 
 
 def critic_refine_action(agent: SACGPSAgent, obs: np.ndarray, action_init: np.ndarray, steps: int, lr: float, l2: float) -> np.ndarray:
@@ -498,7 +498,7 @@ def train_sac_gps_agent(train_cases, traj_cfg, obj_cfg, sac_cfg, total_interacti
         upd = agent.update(sac_cfg.updates_per_interaction)
         if step % max(1, eval_every) == 0 or step == 1:
             eval_rows = evaluate_sac_gps_policy(agent, train_cases[:min(8, len(train_cases))], traj_cfg, obj_cfg, sac_cfg, baseline_cache, seed=seed + 50000 + step, critic_refine=False)
-            mean_existing = float(np.mean([r["existing_metrics"]["total"] for r in eval_rows]))
+            mean_existing = float(np.mean([r["existing_metrics"]["total_cost"] for r in eval_rows]))
             mean_actor = float(np.mean([r["actor_eval"]["cost"] for r in eval_rows]))
             mean_imp = 100.0 * (mean_existing - mean_actor) / max(abs(mean_existing), 1e-12)
             rec = dict(step=step, train_reward=float(ev["reward"]), train_raw_reward=float(ev["raw_reward"]), train_cost=float(ev["cost"]), train_existing_cost=float(ev["existing_cost"]), mean_eval_existing=mean_existing, mean_eval_actor=mean_actor, mean_eval_improvement_pct=mean_imp, buffer=float(agent.replay.len), alpha=float(agent.alpha.detach().cpu().item()))
@@ -537,7 +537,7 @@ def evaluate_sac_gps_policy(agent, test_cases, traj_cfg, obj_cfg, sac_cfg, basel
         zero_ev = evaluate_action(case, zero_action, traj_cfg, obj_cfg, sac_cfg, baseline_cache, seed=seed + 3000 + i)
         best_ev = min([actor_ev, refined_ev, zero_ev], key=lambda d: d["cost"])
         rows.append(dict(case=case, existing_metrics=existing_metrics, existing_logs=existing_logs, existing_ref=existing_ref, existing_T=existing_T, zero_eval=zero_ev, actor_eval=actor_ev, refined_eval=refined_ev, best_eval=best_ev, actor_metrics=actor_ev["metrics"], refined_metrics=refined_ev["metrics"], best_metrics=best_ev["metrics"]))
-        print(f"eval {case.label()}: existing={existing_metrics['total']:.6g}, actor={actor_ev['cost']:.6g}, refined={refined_ev['cost']:.6g}, best={best_ev['cost']:.6g}, best_imp={best_ev['improvement_pct']:.2f}%")
+        print(f"eval {case.label()}: existing={existing_metrics['total_cost']:.6g}, actor={actor_ev['cost']:.6g}, refined={refined_ev['cost']:.6g}, best={best_ev['cost']:.6g}, best_imp={best_ev['improvement_pct']:.2f}%")
     return rows
 
 
@@ -560,7 +560,7 @@ def plot_evaluation_summary(rows, obj_cfg, save_dir=None, show=True):
     if not rows: return
     labels = [f"{r['case'].theta_goal_deg:.0f}/{r['case'].alpha_deg:.0f}" for r in rows]
     x = np.arange(len(rows))
-    existing = np.array([r["existing_metrics"]["total"] for r in rows], float)
+    existing = np.array([r["existing_metrics"]["total_cost"] for r in rows], float)
     actor = np.array([r["actor_eval"]["cost"] for r in rows], float)
     best = np.array([r["best_eval"]["cost"] for r in rows], float)
     fig = plt.figure(figsize=(max(9,.45*len(rows)),5)); plt.plot(x, existing, marker="o", label="LQR"); plt.plot(x, actor, marker="o", label="SAC actor"); plt.plot(x, best, marker="o", label="best")

--- a/trajectory_rl_gps_addon.py
+++ b/trajectory_rl_gps_addon.py
@@ -226,9 +226,13 @@ def simulate_existing_reference(case: CaseSpec, seed: int = 0, theta0: float = 0
 
 
 def trajectory_objective(logs: Dict[str, np.ndarray], theta_goal: float, plant_p, obj_cfg: TrajectoryConstraintConfig) -> Dict[str, float]:
+    required_keys = ("t", "theta", "theta_ref", "omega", "omega_ref", "u_total")
+    missing = [k for k in required_keys if k not in logs]
+    if missing:
+        raise KeyError(f"trajectory_objective missing required log keys: {missing}")
     t = np.asarray(logs["t"], dtype=float)
     if t.size == 0:
-        return {"total": 1e12}
+        return {"total_cost": 1e12}
     dt = float(plant_p.dt)
     theta = np.asarray(logs["theta"], dtype=float)
     theta_ref = np.asarray(logs["theta_ref"], dtype=float)
@@ -264,7 +268,7 @@ def trajectory_objective(logs: Dict[str, np.ndarray], theta_goal: float, plant_p
         + obj_cfg.w_duration * duration
     )
     return dict(
-        total=float(total), energy=energy, track=track, vel_track=vel_track, final=final,
+        total_cost=float(total), energy=energy, track=track, vel_track=vel_track, final=final,
         final_theta_error=final_theta_error, final_omega=final_omega,
         ref_vel_violation=ref_vel_violation, actual_vel_violation=actual_vel_violation,
         torque_violation=torque_violation, command_violation=command_violation, duration=duration,
@@ -319,7 +323,7 @@ def cem_optimize_case(
         eval_cache = []
         for i, p in enumerate(samples):
             metrics, logs, theta_ref, T = evaluate_params_for_case(case, p, traj_cfg, obj_cfg, seed=seed + i)
-            costs[i] = metrics["total"]
+            costs[i] = metrics["total_cost"]
             eval_cache.append((metrics, logs, theta_ref, T))
 
         order = np.argsort(costs)
@@ -331,11 +335,9 @@ def cem_optimize_case(
         mean = 0.35 * mean + 0.65 * elites.mean(axis=0)
         std = 0.35 * std + 0.65 * (elites.std(axis=0) + 1e-3)
         std = np.maximum(std, 0.03)
-        print("base_metrics keys:", base_metrics.keys())
-        print("base_metrics:", base_metrics)
         history.append(dict(iteration=it, best=float(best["cost"]), baseline=float(base_metrics["total_cost"])))
         if verbose:
-            print(f"CEM {case.label()} iter={it:02d}: best={best['cost']:.5g}, baseline={base_metrics['total']:.5g}")
+            print(f"CEM {case.label()} iter={it:02d}: best={best['cost']:.5g}, baseline={base_metrics['total_cost']:.5g}")
 
     best["history"] = history
     best["baseline_metrics"] = base_metrics
@@ -434,8 +436,8 @@ def evaluate_policy_vs_existing(policy: TrajectoryPolicyNet, cases: Sequence[Cas
         base_metrics = trajectory_objective(base_logs, case.theta_goal, plant_p, obj_cfg)
         p = policy_params(policy, case)
         rl_metrics, rl_logs, rl_theta_ref, rl_T = evaluate_params_for_case(case, p, traj_cfg, obj_cfg, seed=seed + i)
-        rows.append(dict(case=case, existing_metrics=base_metrics, rl_metrics=rl_metrics, existing_logs=base_logs, rl_logs=rl_logs, existing_theta_ref=base_theta_ref, rl_theta_ref=rl_theta_ref, existing_duration=base_T, rl_duration=rl_T, rl_params=p, improvement=base_metrics["total"] - rl_metrics["total"], improvement_ratio=(base_metrics["total"] - rl_metrics["total"]) / max(abs(base_metrics["total"]), 1e-12)))
-        print(f"Eval {case.label()}: existing={base_metrics['total']:.5g}, NN-traj={rl_metrics['total']:.5g}, improvement={rows[-1]['improvement_ratio'] * 100:.1f}%")
+        rows.append(dict(case=case, existing_metrics=base_metrics, rl_metrics=rl_metrics, existing_logs=base_logs, rl_logs=rl_logs, existing_theta_ref=base_theta_ref, rl_theta_ref=rl_theta_ref, existing_duration=base_T, rl_duration=rl_T, rl_params=p, improvement=base_metrics["total_cost"] - rl_metrics["total_cost"], improvement_ratio=(base_metrics["total_cost"] - rl_metrics["total_cost"]) / max(abs(base_metrics["total_cost"]), 1e-12)))
+        print(f"Eval {case.label()}: existing={base_metrics['total_cost']:.5g}, NN-traj={rl_metrics['total_cost']:.5g}, improvement={rows[-1]['improvement_ratio'] * 100:.1f}%")
     return rows
 
 
@@ -467,8 +469,8 @@ def plot_evaluation_summary(rows: Sequence[Dict[str, object]], save_dir: Optiona
         return
     labels = [f"{r['case'].theta_goal_deg:.0f}\n{r['case'].alpha_deg:.0f}/{r['case'].phi_deg:.0f}" for r in rows]
     x = np.arange(len(rows))
-    existing = np.array([r["existing_metrics"]["total"] for r in rows], dtype=float)
-    learned = np.array([r["rl_metrics"]["total"] for r in rows], dtype=float)
+    existing = np.array([r["existing_metrics"]["total_cost"] for r in rows], dtype=float)
+    learned = np.array([r["rl_metrics"]["total_cost"] for r in rows], dtype=float)
     fig = plt.figure(figsize=(max(10, len(rows) * 0.55), 5))
     width = 0.4
     plt.bar(x - width/2, existing, width, label="LQR reference")
@@ -498,7 +500,7 @@ def run_full_trajectory_rl_experiment(
     plot_training_progress(train_output, save_dir=save_dir, show=show_plots)
     plot_evaluation_summary(rows, save_dir=save_dir, show=show_plots)
     with open(os.path.join(save_dir, "evaluation_summary.json"), "w") as f:
-        json.dump([dict(theta_goal_deg=r["case"].theta_goal_deg, alpha_deg=r["case"].alpha_deg, phi_deg=r["case"].phi_deg, existing_cost=r["existing_metrics"]["total"], rl_cost=r["rl_metrics"]["total"], improvement_ratio=r["improvement_ratio"]) for r in rows], f, indent=2)
+        json.dump([dict(theta_goal_deg=r["case"].theta_goal_deg, alpha_deg=r["case"].alpha_deg, phi_deg=r["case"].phi_deg, existing_cost=r["existing_metrics"]["total_cost"], rl_cost=r["rl_metrics"]["total_cost"], improvement_ratio=r["improvement_ratio"]) for r in rows], f, indent=2)
     return dict(train_output=train_output, evaluation_rows=rows, traj_cfg=traj_cfg, obj_cfg=obj_cfg)
 
 

--- a/true_gps_lqr_guided_addon.py
+++ b/true_gps_lqr_guided_addon.py
@@ -260,6 +260,10 @@ def simulate_reference(case: GPSCase, theta_ref: np.ndarray, T: float, seed: int
 
 
 def compute_objective(logs: Dict[str, np.ndarray], case: GPSCase, obj: GPSObjectiveConfig, guide_theta_ref: Optional[np.ndarray] = None, guide_T: Optional[float] = None) -> Dict[str, float]:
+    required_keys = ("t", "theta", "theta_ref", "omega", "omega_ref", "u_total")
+    missing = [k for k in required_keys if k not in logs]
+    if missing:
+        raise KeyError(f"compute_objective missing required log keys: {missing}")
     t = np.asarray(logs["t"], dtype=float)
     dt = float(np.mean(np.diff(t))) if len(t) > 1 else float(sysmod.DT)
     theta = np.asarray(logs["theta"], dtype=float)
@@ -311,7 +315,7 @@ def compute_objective(logs: Dict[str, np.ndarray], case: GPSCase, obj: GPSObject
         + obj.w_duration * duration
     )
     return dict(
-        total=float(total), energy=energy, theta_track=theta_track, omega_track=omega_track,
+        total_cost=float(total), energy=energy, theta_track=theta_track, omega_track=omega_track,
         final_theta_error=abs(final_theta_error), final_omega_abs=abs(final_omega),
         max_abs_omega=float(np.max(np.abs(omega))) if len(omega) else 0.0,
         max_abs_omega_ref=float(np.max(np.abs(omega_ref))) if len(omega_ref) else 0.0,
@@ -371,7 +375,7 @@ def cem_optimize_guided_case(
         for j, p in enumerate(candidates):
             try:
                 metrics, logs, theta_ref, T, extra, _, _ = evaluate_guided_params(case, p, traj_cfg, obj_cfg, seed=seed + 1000 * it + j)
-                cost = metrics["total"]
+                cost = metrics["total_cost"]
             except Exception:
                 metrics, logs, theta_ref, T, extra = None, None, None, None, None
                 cost = np.inf
@@ -489,9 +493,9 @@ def plot_evaluation_summary(rows: Sequence[Dict[str, object]], save_dir: Optiona
     if not rows: return
     labels = [f"{r['case'].theta_goal_deg:.0f}\n{r['case'].alpha_deg:.0f}/{r['case'].phi_deg:.0f}" for r in rows]
     x = np.arange(len(rows)); width = 0.25
-    c_existing = np.array([r["existing_metrics"]["total"] for r in rows])
-    c_nn = np.array([r["nn_metrics"]["total"] for r in rows])
-    c_gps = np.array([r["gps_metrics"]["total"] for r in rows])
+    c_existing = np.array([r["existing_metrics"]["total_cost"] for r in rows])
+    c_nn = np.array([r["nn_metrics"]["total_cost"] for r in rows])
+    c_gps = np.array([r["gps_metrics"]["total_cost"] for r in rows])
     fig = plt.figure(figsize=(max(10, len(rows) * 0.55), 5))
     plt.bar(x - width, c_existing, width, label="LQR")
     plt.bar(x, c_nn, width, label="policy")
@@ -505,7 +509,7 @@ def save_evaluation_table(rows: Sequence[Dict[str, object]], save_dir: str):
     table = []
     for r in rows:
         c = r["case"]
-        table.append(dict(theta_goal_deg=c.theta_goal_deg, alpha_deg=c.alpha_deg, phi_deg=c.phi_deg, existing_cost=r["existing_metrics"]["total"], nn_cost=r["nn_metrics"]["total"], gps_cost=r["gps_metrics"]["total"]))
+        table.append(dict(theta_goal_deg=c.theta_goal_deg, alpha_deg=c.alpha_deg, phi_deg=c.phi_deg, existing_cost=r["existing_metrics"]["total_cost"], nn_cost=r["nn_metrics"]["total_cost"], gps_cost=r["gps_metrics"]["total_cost"]))
     with open(os.path.join(save_dir, "true_gps_evaluation_summary.json"), "w") as f:
         json.dump(table, f, indent=2)
 


### PR DESCRIPTION
### Motivation
- Several trajectory/GPS/SAC modules used inconsistent metric keys (`"total"` vs `"total_cost"`) which produced environment-dependent `KeyError`s when different code paths ran. 
- Rollout objective calculators assumed logs always contained certain keys, which made failures hard to diagnose at runtime.  
- There were leftover debug prints in the CEM loops that produced noisy output and leaked internal state during normal runs.

### Description
- Standardized objective dictionaries and all consumers to use `total_cost` (changed in `trajectory_objective`/`compute_objective` and all callers).  
- Added required-log-key validation in `trajectory_objective` and `compute_objective` so missing rollout logs now raise a clear `KeyError` listing the missing keys.  
- Removed debug prints from the CEM optimization loop and updated all plotting/JSON export code to consume `total_cost`.  
- Files modified: `trajectory_rl_gps_addon.py`, `true_gps_lqr_guided_addon.py`, and `sac_gps_lqr_guided_saved_teacher_addon.py`.

### Testing
- Ran `python -m py_compile *.py` and compilation completed successfully.  
- Performed repository-wide grep checks to confirm no remaining consumers read `"total"` and that plotting/JSON export sites now use `"total_cost"`, and these checks passed.  
- Basic smoke-run commands used during verification: `python -m py_compile *.py` and repository searches with `rg`; both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f7a5edb83083289fcd776741b1dda2)