### PR TITLE
Fix TrajectoryPolicyNet crash when PyTorch is unavailable

### DIFF
--- a/trajectory_rl_gps_addon.py
+++ b/trajectory_rl_gps_addon.py
@@ -347,7 +347,7 @@ def cem_optimize_case(
 
 #%% ========================= DEEP TRAJECTORY POLICY =========================
 
-class TrajectoryPolicyNet(nn.Module):
+class TrajectoryPolicyNet(nn.Module if nn is not None else object):
     def __init__(self, cfg: TrajectoryPolicyConfig):
         if torch is None:
             raise RuntimeError(f"PyTorch import failed: {_TORCH_IMPORT_ERROR}")


### PR DESCRIPTION
### Motivation
- Prevent an `AttributeError` at import time when `torch`/`torch.nn` failed to import so the module can still be inspected or used without PyTorch installed.

### Description
- Change `TrajectoryPolicyNet` class declaration to `class TrajectoryPolicyNet(nn.Module if nn is not None else object):` to avoid evaluating `nn.Module` when `nn` is `None` while preserving the existing runtime guard in `__init__` that raises `RuntimeError` with import details.

### Testing
- Ran `python -m py_compile trajectory_rl_gps_addon.py` which succeeded, and created a commit containing the one-line change (`git commit`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8ab6189548328a32fa6b6dcb4d4d8)