### PR TITLE
Extend generated references with 25% post-goal hold

### DIFF
--- a/sac_gps_lqr_guided_saved_teacher_addon.py
+++ b/sac_gps_lqr_guided_saved_teacher_addon.py
@@ -40,6 +40,9 @@ import LQR_TrjOPt_TDESMCwithRLresidual as sysmod
 import true_gps_lqr_guided_addon as gps
 
 
+HOLD_FRACTION_AFTER_GOAL = gps.HOLD_FRACTION_AFTER_GOAL
+
+
 #%% ========================= CONFIG =========================
 
 @dataclass

--- a/trajectory_rl_gps_addon.py
+++ b/trajectory_rl_gps_addon.py
@@ -133,6 +133,27 @@ def _shape_basis(z: np.ndarray, n_shape: int) -> np.ndarray:
     return sysmod.sin_basis(z, n_shape)
 
 
+
+HOLD_FRACTION_AFTER_GOAL = 0.25
+
+
+def _extend_reference_with_goal_hold(
+    theta_ref: np.ndarray,
+    dt: float,
+    hold_fraction: float = HOLD_FRACTION_AFTER_GOAL,
+    theta_goal: Optional[float] = None,
+) -> np.ndarray:
+    """Append a flat tail at theta_goal for a fraction of current trajectory time."""
+    theta_ref = np.asarray(theta_ref, dtype=float).reshape(-1)
+    if theta_ref.size < 2 or hold_fraction <= 0.0:
+        return theta_ref
+    hold_steps = int(round((theta_ref.size - 1) * hold_fraction))
+    if hold_steps <= 0:
+        return theta_ref
+    goal_value = float(theta_ref[-1] if theta_goal is None else theta_goal)
+    return np.r_[theta_ref, np.full(hold_steps, goal_value, dtype=float)]
+
+
 def build_monotone_reference(
     theta_goal: float,
     params: np.ndarray,
@@ -171,7 +192,10 @@ def build_monotone_reference(
     theta_ref = theta0 + delta * h
     theta_ref[0] = theta0
     theta_ref[-1] = theta_goal
+    theta_ref = _extend_reference_with_goal_hold(theta_ref, dt, theta_goal=theta_goal)
     omega_ref = sysmod.finite_diff(theta_ref, dt)
+    t = np.arange(theta_ref.size, dtype=float) * dt
+    T = float(t[-1])
     return t, theta_ref, omega_ref, T
 
 

--- a/true_gps_lqr_guided_addon.py
+++ b/true_gps_lqr_guided_addon.py
@@ -164,6 +164,26 @@ def residual_basis(z: np.ndarray, n_basis: int) -> np.ndarray:
     return sysmod.sin_basis(z, n_basis)
 
 
+HOLD_FRACTION_AFTER_GOAL = 0.25
+
+
+def _extend_reference_with_goal_hold(
+    theta_ref: np.ndarray,
+    dt: float,
+    hold_fraction: float = HOLD_FRACTION_AFTER_GOAL,
+    theta_goal: Optional[float] = None,
+) -> np.ndarray:
+    """Append a flat tail at theta_goal for a fraction of current trajectory time."""
+    theta_ref = np.asarray(theta_ref, dtype=float).reshape(-1)
+    if theta_ref.size < 2 or hold_fraction <= 0.0:
+        return theta_ref
+    hold_steps = int(round((theta_ref.size - 1) * hold_fraction))
+    if hold_steps <= 0:
+        return theta_ref
+    goal_value = float(theta_ref[-1] if theta_goal is None else theta_goal)
+    return np.r_[theta_ref, np.full(hold_steps, goal_value, dtype=float)]
+
+
 def generate_existing_lqr_reference(nom, plant_p, lqr_w, theta0: float, theta_goal: float, dt: float) -> Tuple[np.ndarray, float]:
     """Wrapper around the LQR main file's base-trajectory function."""
     return sysmod.explicit_lqr_reference(
@@ -233,7 +253,10 @@ def build_guided_residual_reference(
     theta_ref = theta0 + delta * np.interp(t / max(T, 1e-12), z, h_gps)
     theta_ref[0] = theta0
     theta_ref[-1] = theta_goal
+    theta_ref = _extend_reference_with_goal_hold(theta_ref, dt, theta_goal=theta_goal)
     omega_ref = sysmod.finite_diff(theta_ref, dt)
+    t = np.arange(theta_ref.size, dtype=float) * dt
+    T = float(t[-1])
     extra = dict(z=z, h_base=h_base, h_gps=h_gps, v_base=v_base, v_gps=v_gps)
     return t, theta_ref, omega_ref, T, extra
 


### PR DESCRIPTION
### Motivation
- Trajectories currently end immediately when `theta_ref` reaches `theta_goal`, but downstream controllers/rollouts need the reference to remain at the goal for a short period after arrival.  This change makes the reference hold `theta_goal` for an additional 25% of the time taken to reach the goal.

### Description
- Introduced `HOLD_FRACTION_AFTER_GOAL = 0.25` and an `_extend_reference_with_goal_hold(...)` helper that appends a flat tail at the goal to `theta_ref` when appropriate. 
- Applied the helper in `build_monotone_reference` in `trajectory_rl_gps_addon.py` so generated NN/GPS references now include the post-goal hold and recompute `omega_ref`, `t`, and `T` to reflect the extended reference. 
- Applied the helper in `build_guided_residual_reference` in `true_gps_lqr_guided_addon.py` to add the same post-goal hold to LQR-guided GPS references and recompute `omega_ref`, `t`, and `T`. 
- Made the SAC addon explicitly mirror the configured hold fraction by importing `HOLD_FRACTION_AFTER_GOAL` from the GPS module so all modules share the same behavior.

### Testing
- Ran `python -m py_compile trajectory_rl_gps_addon.py true_gps_lqr_guided_addon.py sac_gps_lqr_guided_saved_teacher_addon.py` and the files compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f9af8701d483288328a193135fd2a8)