### PR TITLE
Clarify LQR horizon semantics and rollout cost reporting

### DIFF
--- a/LQR_TrjOPt_TDESMCwithRLresidual.py
+++ b/LQR_TrjOPt_TDESMCwithRLresidual.py
@@ -30,8 +30,12 @@ THETA0_DEG = 0.0
 THETA_GOAL_DEG = 10.0
 SEED = 0
 
-# LQR duration override.  This keeps your old behavior where you used
-# reference={"duration": 150.2}.  Set None for automatic 4 sec per pi rad.
+# LQR duration override.  This fixes the planning horizon; LQR does not
+# optimize duration.  If not None, this value is used as the externally
+# prescribed horizon.  If None, the horizon is time_horizon(theta0, theta_goal)
+# (automatic 4 sec per pi rad).  Changing this value changes N = round(T / dt)
+# and therefore the generated finite-horizon reference, but duration is not a
+# decision variable in the LQR cost.
 LQR_DURATION_S = 150.2
 
 # Saved-weight folders/files.
@@ -72,7 +76,12 @@ SUBTRACT_GRAVITY_IN_UEQ = False
 NOMINAL_J = 13000.0
 NOMINAL_B = 0.06
 
-# LQR trajectory weights.
+# LQR trajectory-generation weights for the nominal 2-state planner:
+#   x = [theta, omega], u = direct nominal torque/input
+#   sum_k q_theta*(theta_k-theta_goal)^2 + q_omega*omega_k^2 + r_u*u_k^2
+#   + qT_theta*(theta_N-theta_goal)^2 + qT_omega*omega_N^2
+# The planner has no tau_m servo state, no w_time/J_time term, and does not
+# choose duration.  Duration only sets N = round(T / dt).
 LQR_Q_THETA = 85.0
 LQR_Q_OMEGA = 18.0
 LQR_R_U = 0.02
@@ -107,7 +116,12 @@ PP_SMC_LAMBDA = 45.0
 PP_SMC_K = 80.0
 PP_SMC_PHI = 0.05
 
-# Rollout cost used only for reporting total_cost.
+# Closed-loop rollout reporting/evaluation cost weights.
+# This total_cost is computed after theta_ref is generated and tracked by
+# TDE+SMC on the plant.  It is not the finite-horizon LQR planning objective.
+# COST_W_TIME contributes only to rollout reporting/evaluation; it is not used
+# by the LQR planner unless an external optimizer separately treats rollout_once
+# as its objective.
 COST_W_E = 8.0
 COST_W_EDOT = 1.0
 COST_W_U = 0.03
@@ -357,6 +371,8 @@ def build_AB(nom: NominalModel, dt: float) -> Tuple[np.ndarray, np.ndarray]:
     return A, B
 
 def finite_horizon_lqr_gain(A: np.ndarray, B: np.ndarray, N: int, w: LQRWeights) -> List[np.ndarray]:
+    # Finite-horizon nominal LQR objective only: state error and direct input.
+    # There is no duration, w_time, J_time, or actuator servo state in this planner.
     Q = np.diag([w.q_theta, w.q_omega])
     R = np.array([[w.r_u]])
     Qf = np.diag([w.qT_theta, w.qT_omega])
@@ -379,8 +395,11 @@ def generate_reference_ilqr_like(nom: NominalModel, plant_limits: PlantParams, x
         x_tilde = x - x_goal
         excess = abs(x[1]) - plant_limits.omega_max
         if excess > 0:
+            # Speed-limit penalty/heuristic inside trajectory generation.
+            # This is not a duration penalty.
             x_tilde[1] += w.omega_limit_penalty * excess * math.copysign(1.0, x[1])
         u = float((-Ks[k] @ x_tilde.reshape(2, 1)).item())
+        # Planner command saturation; the LQR model itself has no tau_m servo state.
         u = sat(u, plant_limits.u_max)
         x = A @ x + B.flatten() * u
         x_ref[k, :] = x
@@ -392,6 +411,8 @@ def time_horizon(theta0: float, theta_goal: float) -> float:
     return 4.0 * abs(theta_goal - theta0) / math.pi if abs(theta_goal - theta0) > 1e-12 else 0.5
 
 def explicit_lqr_reference(theta0: float, theta_goal: float, plant_p: PlantParams, nom: NominalModel, lqr_w: LQRWeights, duration: Optional[float] = None) -> Tuple[np.ndarray, float]:
+    # Duration is an externally prescribed planning horizon, not an optimized
+    # LQR cost term.  It affects the reference only through N = round(T / dt).
     T = time_horizon(theta0, theta_goal) if duration is None else float(duration)
     N = max(1, int(round(T / plant_p.dt)))
     T = N * plant_p.dt
@@ -816,6 +837,9 @@ def load_rl_reference(theta0: float, theta_goal: float, plant_p: PlantParams, no
 def build_trajectory_reference(trj_type: str, theta0: float, theta_goal: float, plant_p: PlantParams, nom: NominalModel, lqr_w: LQRWeights) -> Optional[Dict[str, object]]:
     kind = str(trj_type).upper()
     if kind == "LQR":
+        # LQR_DURATION_S fixes the horizon when provided.  If it is None,
+        # rollout_once uses time_horizon(theta0, theta_goal).  In both cases,
+        # the LQR planner does not optimize duration; the horizon only sets N.
         if LQR_DURATION_S is None:
             return None
         return {"kind": "LQR", "duration": float(LQR_DURATION_S)}
@@ -953,6 +977,10 @@ def rollout_once(
         pp_eps_dot_log = np.full(N, np.nan)
         pp_violation_log = np.zeros(N)
 
+    # Closed-loop rollout reporting/comparison cost.
+    # This is not the same as the finite-horizon LQR objective used to generate
+    # theta_ref.  J_time appears only here in reporting/evaluation; it is not
+    # part of the LQR planner cost.
     J_e = 0.0
     J_edot = 0.0
     J_omega = 0.0
@@ -1147,7 +1175,7 @@ def plot_rollout(logs: Dict[str, np.ndarray]) -> None:
     final_error = float(theta[-1] - theta_goal)
 
     print(f"Trajectory type = {trj_type}")
-    print(f"Total rollout cost = {logs['metrics']['total_cost']:.6g}")
+    print(f"Total rollout reporting cost = {logs['metrics']['total_cost']:.6g}")
     print(f"Energy metric J_u = {J_u:.6g} N.m^2.s")
     print(f"Final angle error = {final_error:.6f} rad ({math.degrees(final_error):.3f} deg)")
 
@@ -1210,15 +1238,19 @@ def plot_rollout(logs: Dict[str, np.ndarray]) -> None:
 logs_demo = evaluate_and_rollout(TRJ_TYPE)
 print(f"Trajectory type = {TRJ_TYPE}")
 print(f"Reference kind = {logs_demo.get('reference_kind')}")
-print(f"Total cost = {logs_demo['metrics']['total_cost']:.6g}")
+if str(TRJ_TYPE).upper() == "LQR":
+    horizon_source = "LQR_DURATION_S" if LQR_DURATION_S is not None else "time_horizon(theta0, theta_goal)"
+    print(f"LQR planning horizon source = {horizon_source}; duration is fixed before planning and is not optimized by LQR.")
+    print("LQR planning cost has no w_time/J_time term; J_time below is rollout reporting only.")
+print(f"Total rollout reporting cost = {logs_demo['metrics']['total_cost']:.6g}")
 m = logs_demo["metrics"]
 print("\n=== Cost breakdown ===")
 print(f"J_e      = {m['J_e']:.6g}")
 print(f"J_edot   = {m['J_edot']:.6g}")
 print(f"J_omega  = {m['J_omega']:.6g}")
-print(f"J_time   = {m['J_time']:.6g}")
+print(f"J_time (rollout reporting only; not used by LQR planner) = {m['J_time']:.6g}")
 print(f"duration = {m['duration']:.6g} s")
-print(f"total    = {m['total_cost']:.6g}")
+print(f"total rollout reporting cost = {m['total_cost']:.6g}")
 
 
 #%% ========================= PLOT ROLLOUT =========================

--- a/sac_gps_lqr_guided_saved_teacher_addon.py
+++ b/sac_gps_lqr_guided_saved_teacher_addon.py
@@ -8,6 +8,10 @@ This file trains/loads the SAC actor, but all plant parameters, base LQR
 trajectory, TDE+SMC rollout, and physical simulation are delegated to:
     true_gps_lqr_guided_addon.py -> LQR_TrjOPt_TDESMCwithRLresidual.py
 
+The SAC/GPS reward compares closed-loop rollout objective values.  It is not
+the finite-horizon LQR planning objective: the LQR baseline duration is fixed
+externally, while the SAC/GPS trajectory parameterization may choose duration.
+
 Saved model format:
     save_dir/sac_gps_agent.pt/actor.keras
     save_dir/sac_gps_agent.pt/q1.keras
@@ -479,7 +483,7 @@ def prefill_from_saved_teachers(agent, train_cases, traj_cfg, obj_cfg, sac_cfg, 
         bc_obs.append(obs); bc_act.append(best_action)
         rows.append(dict(case=case, zero_eval=zero_ev, best_eval=best_ev, best_action=best_action, saved_teacher=saved))
         found_cases.append(case.label())
-        print(f"saved teacher {i+1}/{len(train_cases)}: {case.label()} | existing={best_ev['existing_cost']:.6g}, cost={best_ev['cost']:.6g}, improvement={best_ev['improvement_pct']:.2f}%")
+        print(f"saved teacher {i+1}/{len(train_cases)}: {case.label()} | fixed-horizon LQR rollout objective={best_ev['existing_cost']:.6g}, teacher rollout objective={best_ev['cost']:.6g}, improvement={best_ev['improvement_pct']:.2f}%")
     print(f"Saved teacher prefill found {len(found_cases)}/{len(train_cases)} cases.")
     if found_cases:
         print("Cases with saved teachers: " + ", ".join(found_cases))
@@ -850,7 +854,7 @@ def evaluate_sac_gps_policy(agent, test_cases, traj_cfg, obj_cfg, sac_cfg, basel
         zero_ev = evaluate_action(case, zero_action, traj_cfg, obj_cfg, sac_cfg, baseline_cache, seed=seed + 3000 + i)
         best_ev = min([actor_ev, refined_ev, zero_ev], key=lambda d: d["cost"])
         rows.append(dict(case=case, existing_metrics=existing_metrics, existing_logs=existing_logs, existing_ref=existing_ref, existing_T=existing_T, zero_eval=zero_ev, actor_eval=actor_ev, refined_eval=refined_ev, best_eval=best_ev, actor_metrics=actor_ev["metrics"], refined_metrics=refined_ev["metrics"], best_metrics=best_ev["metrics"]))
-        print(f"eval {case.label()}: existing={existing_metrics['total_cost']:.6g}, actor={actor_ev['cost']:.6g}, refined={refined_ev['cost']:.6g}, best={best_ev['cost']:.6g}, best_imp={best_ev['improvement_pct']:.2f}%")
+        print(f"eval {case.label()}: fixed-horizon LQR rollout objective={existing_metrics['total_cost']:.6g}, actor rollout objective={actor_ev['cost']:.6g}, refined rollout objective={refined_ev['cost']:.6g}, best={best_ev['cost']:.6g}, best_imp={best_ev['improvement_pct']:.2f}%")
     return rows
 
 
@@ -877,15 +881,15 @@ def plot_evaluation_summary(rows, obj_cfg, save_dir=None, show=True):
     existing = np.array([r["existing_metrics"]["total_cost"] for r in rows], float)
     actor = np.array([r["actor_eval"]["cost"] for r in rows], float)
     best = np.array([r["best_eval"]["cost"] for r in rows], float)
-    fig = plt.figure(figsize=(max(9,.45*len(rows)),5)); plt.plot(x, existing, marker="o", label="LQR"); plt.plot(x, actor, marker="o", label="SAC actor"); plt.plot(x, best, marker="o", label="best")
-    plt.xticks(x, labels, rotation=60, ha="right"); plt.ylabel("objective cost"); plt.title("Trajectory objective comparison"); plt.grid(True, alpha=.4); plt.legend(); _save_or_show(fig, save_dir, "eval_cost_comparison.png", show)
+    fig = plt.figure(figsize=(max(9,.45*len(rows)),5)); plt.plot(x, existing, marker="o", label="fixed-horizon LQR rollout"); plt.plot(x, actor, marker="o", label="SAC actor"); plt.plot(x, best, marker="o", label="best")
+    plt.xticks(x, labels, rotation=60, ha="right"); plt.ylabel("closed-loop rollout objective cost"); plt.title("Trajectory rollout objective comparison"); plt.grid(True, alpha=.4); plt.legend(); _save_or_show(fig, save_dir, "eval_cost_comparison.png", show)
 
 
 def print_constraint_report(rows, obj_cfg):
     print("\n=== Constraint / improvement report ===")
     for r in rows:
         case = r["case"]; best = r["best_eval"]; m = best["metrics"]
-        print(f"{case.label()}: existing={best['existing_cost']:.6g}, best={best['cost']:.6g}, imp={best['improvement_pct']:.2f}%, max|omega|={m['max_abs_omega']:.4g}/{obj_cfg.omega_limit}, max|tau_m|={m['max_abs_tau_m']:.4g}/{obj_cfg.torque_limit}, max|u|={m['max_abs_u_total']:.4g}/{obj_cfg.command_limit}, final_err={m['final_theta_error']:.4g}")
+        print(f"{case.label()}: fixed-horizon LQR rollout objective={best['existing_cost']:.6g}, best rollout objective={best['cost']:.6g}, imp={best['improvement_pct']:.2f}%, max|omega|={m['max_abs_omega']:.4g}/{obj_cfg.omega_limit}, max|tau_m|={m['max_abs_tau_m']:.4g}/{obj_cfg.torque_limit}, max|u|={m['max_abs_u_total']:.4g}/{obj_cfg.command_limit}, final_err={m['final_theta_error']:.4g}")
 
 
 #%% ========================= USER SETTINGS =========================

--- a/trajectory_rl_gps_addon.py
+++ b/trajectory_rl_gps_addon.py
@@ -9,6 +9,15 @@ plant, controller, LQR model, or physical parameters.  Every system rollout,
 base LQR trajectory, and TDE+SMC command comes from
 LQR_TrjOPt_TDESMCwithRLresidual.py.
 
+Cost terminology:
+    - The base LQR trajectory uses the fixed-horizon nominal LQR planning
+      objective in the main file.  Its duration is prescribed by
+      LQR_DURATION_S, or by time_horizon(...) when LQR_DURATION_S is None;
+      LQR does not optimize duration and has no w_time/J_time term.
+    - The NN/GPS trajectory objective below is a separate closed-loop rollout
+      objective.  It may include duration because this learned trajectory
+      parameterization chooses duration.
+
 Saved model format is unchanged:
     save_dir/trajectory_policy.pt
     save_dir/training_cases.json
@@ -202,6 +211,9 @@ def build_monotone_reference(
 # ========================= SYSTEM ROLLOUT THROUGH LQR MAIN FILE =========================
 
 def base_lqr_reference(case: CaseSpec, theta0: float = 0.0) -> Tuple[np.ndarray, float]:
+    # Fixed-horizon nominal LQR reference from the main file.  LQR_DURATION_S
+    # prescribes the horizon when set; otherwise time_horizon(...) is used.
+    # The LQR planner does not optimize duration.
     plant_p, nom, lqr_w, _, _ = system_for_case(case)
     return sysmod.explicit_lqr_reference(
         theta0=theta0,
@@ -239,6 +251,10 @@ def simulate_existing_reference(case: CaseSpec, seed: int = 0, theta0: float = 0
 
 
 def trajectory_objective(logs: Dict[str, np.ndarray], theta_goal: float, plant_p, obj_cfg: TrajectoryConstraintConfig) -> Dict[str, float]:
+    # Closed-loop trajectory-learning objective evaluated after rollout.
+    # This is separate from the finite-horizon LQR planning objective used to
+    # generate the baseline theta_ref.  Its duration term belongs to NN/GPS
+    # teacher evaluation, not to the LQR planner.
     required_keys = ("t", "theta", "theta_ref", "omega", "omega_ref", "u_total")
     missing = [k for k in required_keys if k not in logs]
     if missing:
@@ -541,7 +557,7 @@ def evaluate_policy_vs_existing(policy: TrajectoryPolicyNet, cases: Sequence[Cas
         p = policy_params(policy, case)
         rl_metrics, rl_logs, rl_theta_ref, rl_T = evaluate_params_for_case(case, p, traj_cfg, obj_cfg, seed=seed + i)
         rows.append(dict(case=case, existing_metrics=base_metrics, rl_metrics=rl_metrics, existing_logs=base_logs, rl_logs=rl_logs, existing_theta_ref=base_theta_ref, rl_theta_ref=rl_theta_ref, existing_duration=base_T, rl_duration=rl_T, rl_params=p, improvement=base_metrics["total_cost"] - rl_metrics["total_cost"], improvement_ratio=(base_metrics["total_cost"] - rl_metrics["total_cost"]) / max(abs(base_metrics["total_cost"]), 1e-12)))
-        print(f"Eval {case.label()}: existing={base_metrics['total_cost']:.5g}, NN-traj={rl_metrics['total_cost']:.5g}, improvement={rows[-1]['improvement_ratio'] * 100:.1f}%")
+        print(f"Eval {case.label()}: fixed-horizon LQR rollout objective={base_metrics['total_cost']:.5g}, NN-traj rollout objective={rl_metrics['total_cost']:.5g}, improvement={rows[-1]['improvement_ratio'] * 100:.1f}%")
     return rows
 
 
@@ -577,10 +593,10 @@ def plot_evaluation_summary(rows: Sequence[Dict[str, object]], save_dir: Optiona
     learned = np.array([r["rl_metrics"]["total_cost"] for r in rows], dtype=float)
     fig = plt.figure(figsize=(max(10, len(rows) * 0.55), 5))
     width = 0.4
-    plt.bar(x - width/2, existing, width, label="LQR reference")
+    plt.bar(x - width/2, existing, width, label="fixed-horizon LQR rollout")
     plt.bar(x + width/2, learned, width, label="NN/GPS reference")
     plt.xticks(x, labels, rotation=45, ha="right")
-    plt.ylabel("objective cost")
+    plt.ylabel("closed-loop rollout objective cost")
     plt.title("Cost comparison")
     plt.legend(); plt.grid(True, axis="y", linestyle="--", alpha=0.6)
     _maybe_save(fig, save_dir, "cost_comparison.png", show)
@@ -726,8 +742,8 @@ improvement = lqr_cost - gps_cost
 improvement_ratio = improvement / max(abs(lqr_cost), 1e-12)
 
 print("\n---------------- RESULTS ----------------")
-print(f"LQR total cost     = {lqr_cost:.6g}")
-print(f"NN/GPS total cost  = {gps_cost:.6g}")
+print(f"Fixed-horizon LQR closed-loop rollout objective cost = {lqr_cost:.6g}")
+print(f"NN/GPS closed-loop rollout objective cost            = {gps_cost:.6g}")
 print(f"Improvement        = {improvement:.6g}")
 print(f"Improvement ratio  = {100.0 * improvement_ratio:.2f} %")
 

--- a/true_gps_lqr_guided_addon.py
+++ b/true_gps_lqr_guided_addon.py
@@ -10,6 +10,15 @@ LQR_TrjOPt_TDESMCwithRLresidual.py for:
     - base LQR trajectory
     - TDE+SMC rollout and control command generation
 
+Cost terminology:
+    - The base LQR trajectory uses a fixed, externally prescribed horizon.
+      LQR_DURATION_S sets that horizon when not None; otherwise the main
+      file's time_horizon(...) is used.  The LQR planner does not optimize
+      duration and has no w_time/J_time cost.
+    - The GPS teacher objective in this file is a separate closed-loop rollout
+      objective.  It may penalize duration because the GPS trajectory
+      parameterization includes duration as a decision variable.
+
 Saved files:
     save_dir/true_gps_policy.keras
     save_dir/training_teachers.json
@@ -198,7 +207,9 @@ def _extend_reference_with_goal_hold(
 
 
 def generate_existing_lqr_reference(nom, plant_p, lqr_w, theta0: float, theta_goal: float, dt: float) -> Tuple[np.ndarray, float]:
-    """Wrapper around the LQR main file's base-trajectory function."""
+    """Wrapper around the main file's fixed-horizon LQR reference."""
+    # LQR_DURATION_S prescribes the horizon when set; otherwise the main file
+    # uses time_horizon(...).  The LQR planner does not optimize duration.
     return sysmod.explicit_lqr_reference(
         theta0=theta0,
         theta_goal=theta_goal,
@@ -296,6 +307,9 @@ def simulate_reference(case: GPSCase, theta_ref: np.ndarray, T: float, seed: int
 
 
 def compute_objective(logs: Dict[str, np.ndarray], case: GPSCase, obj: GPSObjectiveConfig, guide_theta_ref: Optional[np.ndarray] = None, guide_T: Optional[float] = None) -> Dict[str, float]:
+    # Closed-loop GPS teacher/evaluation objective, not the LQR planning cost.
+    # Its duration term can shape GPS teachers because GPS chooses trajectory
+    # duration; it is not a duration term in the fixed-horizon LQR planner.
     required_keys = ("t", "theta", "theta_ref", "omega", "omega_ref", "u_total")
     missing = [k for k in required_keys if k not in logs]
     if missing:
@@ -625,10 +639,10 @@ def plot_evaluation_summary(rows: Sequence[Dict[str, object]], save_dir: Optiona
     c_nn = np.array([r["nn_metrics"]["total_cost"] for r in rows])
     c_gps = np.array([r["gps_metrics"]["total_cost"] for r in rows])
     fig = plt.figure(figsize=(max(10, len(rows) * 0.55), 5))
-    plt.bar(x - width, c_existing, width, label="LQR")
+    plt.bar(x - width, c_existing, width, label="fixed-horizon LQR rollout")
     plt.bar(x, c_nn, width, label="policy")
     plt.bar(x + width, c_gps, width, label="GPS refined")
-    plt.xticks(x, labels, rotation=45, ha="right"); plt.ylabel("objective cost"); plt.title("Trajectory objective comparison")
+    plt.xticks(x, labels, rotation=45, ha="right"); plt.ylabel("closed-loop rollout objective cost"); plt.title("Trajectory rollout objective comparison")
     plt.legend(); plt.grid(True, axis="y", linestyle="--", alpha=0.6); _save_or_show(fig, save_dir, "summary_objective_cost.png", show)
 
 


### PR DESCRIPTION
### Motivation
- Correct mistaken messaging that LQR optimizes duration and/or includes a time penalty in its planning cost.  LQR uses a fixed, externally prescribed horizon (or `time_horizon(...)` when unset). 
- Make a clear distinction between the finite-horizon nominal LQR planning objective and the closed-loop rollout reporting/evaluation objective so comparisons (LQR vs NN/GPS/SAC) are unambiguous. 
- Keep controller and planner behavior unchanged while improving comments, labels, and printed diagnostics so users are not misled about what is being optimized.

### Description
- LQR_TrjOPt_TDESMCwithRLresidual.py: added explanatory comments around `LQR_DURATION_S`, `finite_horizon_lqr_gain`, `generate_reference_ilqr_like`, and `explicit_lqr_reference` to state that duration is prescribed (not optimized) and that the LQR planner uses the 2-state nominal objective (no `tau_m`, no `w_time`/`J_time`).
- LQR_TrjOPt_TDESMCwithRLresidual.py: renamed printed outputs from generic "Total cost" to "Total rollout reporting cost", annotated `J_time` as "rollout reporting only / not used by LQR planner", and adjusted related printouts and labels in `plot_rollout`/run-summary to emphasize reporting vs planning costs.
- Helper scripts/docs: updated `trajectory_rl_gps_addon.py`, `true_gps_lqr_guided_addon.py`, and `sac_gps_lqr_guided_saved_teacher_addon.py` to document cost terminology, to label plots/prints explicitly as fixed-horizon LQR rollout vs closed-loop rollout objective, and to make comparison printouts/legends unambiguous about which cost is being reported.
- Minor clarifying comments added where a speed-limit heuristic and command saturation occur inside the LQR trajectory generator to emphasize these are planner heuristics (not duration penalties) and that planner has no actuator servo state.
- No control logic, optimization loops, or trajectory generation behavior (numerics) were changed; only comments, diagnostic strings, labels, and reporting text were modified.

### Testing
- Ran Python byte-compile checks with `python -m py_compile LQR_TrjOPt_TDESMCwithRLresidual.py trajectory_rl_gps_addon.py true_gps_lqr_guided_addon.py sac_gps_lqr_guided_saved_teacher_addon.py` which completed without errors. 
- Ran repository sanity checks with `git diff --check` which reported no outstanding issues after edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ff6856a9c483289abb0113c0446e22)